### PR TITLE
Don't show error if no package.json found

### DIFF
--- a/common.js
+++ b/common.js
@@ -186,7 +186,7 @@ module.exports = {
     try {
       return JSON.parse(platform.readTextFileSync(path.join(modulePath, "package.json")));
     } catch(e) {
-      log.error(`No package json found for ${name}`);
+      log.debug(`No package json found for ${name}`);
       return {};
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",


### PR DESCRIPTION
Package.json is optional if default of index.js is available.