### PR TITLE
Port getFreeDiskSpace from rise-common-electron

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const {platform} = require("rise-common-electron");
+const portedPlatform = require("./platform")
 const EventEmitter = require('events');
 global.log = global.log || {error:console.log,debug:console.log};
 let lmsClient = null, ipcConnection = null;
@@ -12,7 +13,7 @@ function getDisplaySettingsFileName() {
 function connect(id) {
   if (ipcConnection) {
     return ipcConnection;
-  }     
+  }
   ipcConnection = new Promise((resolve)=>{
     if (lmsClient) {
       resolve(lmsClient);
@@ -55,7 +56,7 @@ function connect(id) {
                       ipc.log('disconnected from lms');
                   }
               );
-            
+
               ipc.of.lms.on(
                   'error',
                   function(){
@@ -232,4 +233,5 @@ module.exports = {
     const filePath = path.join(module.exports.getInstallDir(version), fileName);
     return platform.writeTextFileSync(filePath, data);
   },
+  platform: portedPlatform,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/platform.js
+++ b/platform.js
@@ -1,0 +1,34 @@
+const childProcess = require("child_process")
+
+// Functions being ported from rise-common-electron to avoid dependencies upon that other project.
+// More functions may be ported later.
+module.exports = {
+  getOS() {
+    return process.platform;
+  },
+  isWindows() {
+    return module.exports.getOS() === "win32";
+  },
+  getFreeDiskSpace(dir=__dirname) {
+    return new Promise((resolve, reject)=>{
+      if(module.exports.isWindows()) {
+        var winCommand = "wmic LogicalDisk Where \"Name='DRIVE:'\" GET FreeSpace".replace("DRIVE", dir.substr(0, 1));
+
+        childProcess.exec(winCommand, (err, stdout)=>{
+          if(err) { reject(err); }
+
+          resolve(Number(stdout.split("\n")[1]));
+        });
+      }
+      else {
+        var lnxCommand = "df -k " + dir + " | awk 'NR==2 {print $4}'";
+
+        childProcess.exec(lnxCommand, (err, stdout)=>{
+          if(err) { reject(err); }
+
+          resolve(Number(stdout) * 1024);
+        });
+      }
+    });
+  },
+}

--- a/test/unit/platform.js
+++ b/test/unit/platform.js
@@ -1,0 +1,91 @@
+const assert = require("assert")
+const childProcess = require("child_process")
+const path = require("path")
+const platform = require("../../platform")
+const simpleMock = require("simple-mock")
+
+const mock = simpleMock.mock
+
+var diskSpaceOutputWin =
+`FreeSpace
+265906098176     `;
+
+var diskSpaceOutputLnx =
+`70538216`;
+
+describe("platform", ()=>{
+
+  beforeEach("setup mocks", ()=>{
+  });
+
+  afterEach("clean mocks", ()=>{
+    simpleMock.restore();
+  });
+
+  it("returns free disk space with dir as parameter on linux", ()=>{
+    var installDir = "/home/rise/rvplayer";
+    var dir = "/home/rise/rvplayer/test";
+
+    mock(platform, "isWindows").returnWith(false);
+    mock(platform, "getInstallDir").returnWith(installDir);
+    mock(childProcess, "exec").callbackWith(null, diskSpaceOutputLnx);
+
+    return platform.getFreeDiskSpace(dir)
+    .then((space)=>{
+      assert(childProcess.exec.called);
+      assert.equal(childProcess.exec.lastCall.args[0], "df -k " + dir + " | awk 'NR==2 {print $4}'");
+      assert.equal(space, 72231133184);
+    });
+  });
+
+  it("returns free disk space on Linux", ()=>{
+    mock(platform, "isWindows").returnWith(false);
+    mock(childProcess, "exec").callbackWith(null, diskSpaceOutputLnx);
+
+    return platform.getFreeDiskSpace()
+      .then((space)=>{
+      assert(childProcess.exec.called);
+    assert.equal(childProcess.exec.lastCall.args[0], "df -k " + path.join(__dirname, "..", "..") + " | awk 'NR==2 {print $4}'");
+    assert.equal(space, 72231133184);
+    });
+  });
+
+  it("fails to return free disk space on Linux", ()=>{
+    var installDir = "/home/rise/rvplayer";
+
+    mock(platform, "isWindows").returnWith(false);
+    mock(platform, "getInstallDir").returnWith(installDir);
+    mock(childProcess, "exec").callbackWith("error");
+
+    return platform.getFreeDiskSpace()
+    .catch((err)=>{
+      assert.equal(err, "error");
+    });
+  });
+
+  it("returns free disk space on Windows", ()=>{
+    mock(platform, "isWindows").returnWith(true);
+    mock(childProcess, "exec").callbackWith(null, diskSpaceOutputWin);
+
+    return platform.getFreeDiskSpace()
+    .then((space)=>{
+      assert(childProcess.exec.called);
+      assert.equal(childProcess.exec.lastCall.args[0], `wmic LogicalDisk Where "Name='${__dirname.substr(0,1)}:'" GET FreeSpace`);
+      assert.equal(space, 265906098176);
+    });
+  });
+
+  it("fails to return free disk space on Windows", ()=>{
+    var installDir = "C:\\Users\\rise\\AppData\\Local\\rvplayer";
+
+    mock(platform, "isWindows").returnWith(true);
+    mock(platform, "getInstallDir").returnWith(installDir);
+    mock(childProcess, "exec").callbackWith("error");
+
+    return platform.getFreeDiskSpace()
+      .catch((err)=>{
+        assert.equal(err, "error");
+      });
+  });
+
+});


### PR DESCRIPTION
No functionality changed, just ported it and also functions it depends on.
Unit tests also ported.

This is used on system metrics module but electron dependencies had to be avoided.

Please review changes.