### PR TITLE
Include id in "connected" event data so node-ipc applies it as socket id

### DIFF
--- a/common.js
+++ b/common.js
@@ -31,7 +31,7 @@ function connect(id) {
                   'connect',
                   () => {
                       ipc.log('## connected to lms ##', ipc.config.id);
-                      ipc.of.lms.emit("connected", {client: ipc.config.id});
+                      ipc.of.lms.emit("connected", {id: ipc.config.id, client: ipc.config.id});
 
                       lmsClient = {
                         broadcastMessage: (message) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -120,7 +120,7 @@ describe("Config", ()=>{
 
       it("should emit 'connected' upon connection", (done)=>{
         const connectedHandler = (data) => {
-          assert.deepEqual(data, {client: "broadcaster"});
+          assert.deepEqual(data, {id: "broadcaster", client: "broadcaster"});
           ipc.server.off("connected", connectedHandler);
           done();
         };


### PR DESCRIPTION
@Rise-Vision/delivery The only way an `id` is set on a client socket is if an `id` prop is included in message data from a client socket. See [here](https://github.com/RIAEvangelist/node-ipc/blob/94249c24ea524151a33455196a8490cd0a9e0fcb/dao/socketServer.js#L187-L190). 

It is necessary for a client socket id to be set so Local Messaging module will know which client socket disconnected when it receives `socket.disconnected` event. See [here](https://github.com/RIAEvangelist/node-ipc/blob/94249c24ea524151a33455196a8490cd0a9e0fcb/dao/socketServer.js#L138-L152). 