### PR TITLE
Save newline delimited JSON manifest to GCS for BQ table in stable build

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,13 @@ mkdir -p manifests
 gsutil -m cp gs://install-versions.risevision.com/${OUTPUTDIR}${MANIFESTFILES} manifests
 find manifests -name "*.json" -exec node ./node_modules/common-display-module/update-module-version.js '{}' $MODULENAME $VERSION $ROLLOUTPCT \;
 
+if [ "$BRANCH" = "STABLE" ]
+then
+  jq -c "." manifests/display-modules-manifest.json > manifests/temp.json
+  cp manifests/temp.json manifests/display-modules-manifest.json
+  rm manifests/temp.json
+fi
+
 gsutil -m cp manifests/*.json gs://install-versions.risevision.com/staging/$MODULENAME/$VERSION
 gsutil setmeta -h "Cache-Control:private, max-age=0" gs://install-versions.risevision.com/staging/$MODULENAME/$VERSION/*
 gsutil setmeta -h "Content-Disposition:attachment" gs://install-versions.risevision.com/staging/$MODULENAME/$VERSION/*.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.0.3",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -65,7 +65,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.3.5",
+        "readable-stream": "2.3.6",
         "safe-buffer": "5.1.1"
       },
       "dependencies": {
@@ -80,23 +80,23 @@
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",


### PR DESCRIPTION
- Leverage `jq` which is pre-installed via docker image in CCI - https://github.com/Rise-Vision/rise-launcher-electron/blob/master/.circleci/images/jenkinsrise-cci-v2-launcher-electron:0.0.6#L39-L40

**Note**
Tested locally and it correctly creates our manifest JSON without spaces and newlines as so:

`{"rolloutPct":0,"modules":[{"name":"launcher","version":"2018.04.17.18.56","url":"https://storage.googleapis.com/install-versions.risevision.com/installer-lnx-32.sh","archiveSize":0,"extractedSize":0,"contentHash":""},{"name":"player-electron","version":"2018.04.24.16.40","url":"https://storage.googleapis.com/install-versions.risevision.com/player-electron.sh","archiveSize":0,"extractedSize":0,"contentHash":""}, ... ]}`