### PR TITLE
Feature/cache display settings

### DIFF
--- a/common.js
+++ b/common.js
@@ -35,13 +35,14 @@ function getDisplaySettings() {
 }
 
 function readDisplaySettings() {
-  const configExists = platform.fileExists(getDisplaySettingsFileName());
+  const displaySettingsFileName = getDisplaySettingsFileName();
+  const configExists = platform.fileExists(displaySettingsFileName);
 
   if (!configExists) {
     return {};
   }
 
-  const textFileString = platform.readTextFileSync(getDisplaySettingsFileName());
+  const textFileString = platform.readTextFileSync(displaySettingsFileName);
 
   if (!textFileString) {
     return {};

--- a/common.js
+++ b/common.js
@@ -95,7 +95,8 @@ function updateDisplaySettings(newSettings){
       updatedSettings[key] != null ? `${key}=${updatedSettings[key]}\n` : ''
     ), "");
 
-    return platform.writeTextFile(displaySettingsFileName, updatedSettingsText);
+    return platform.writeTextFile(displaySettingsFileName, updatedSettingsText)
+    .then(() => {displaySettings = updatedSettings;});
   });
 }
 

--- a/common.js
+++ b/common.js
@@ -11,24 +11,34 @@ function getDisplaySettingsFileName() {
 
 function getDisplaySettings() {
   return platform.readTextFile(getDisplaySettingsFileName())
-  .then((contents) => parsePropertyList(contents))
+  .then(parsePropertyList)
   .catch(() => {});
 }
 
-function getTempDisplayId() {
-  return "0." + module.exports.getMachineId();
+function readDisplaySettings() {
+  const configExists = platform.fileExists(getDisplaySettingsFileName());
+
+  if (!configExists) {
+    return {};
+  }
+
+  const textFileString = platform.readTextFileSync(getDisplaySettingsFileName());
+
+  if (!textFileString) {
+    return {};
+  }
+
+  return parsePropertyList(textFileString);
 }
 
 function getDisplaySettingsSync() {
-  var settings,
-    configExists = platform.fileExists(getDisplaySettingsFileName()),
-    textFileString = configExists ? platform.readTextFileSync(getDisplaySettingsFileName()) : "";
+  const settings = readDisplaySettings();
 
-  if (!textFileString) {return {tempdisplayid: getTempDisplayId()};}
+  if (!settings.displayid) {
+    const tempDisplayId = "0." + module.exports.getMachineId();
 
-  settings = parsePropertyList(textFileString);
-
-  if (!settings.displayid) {settings.tempdisplayid = getTempDisplayId();}
+    settings.tempdisplayid = tempDisplayId;
+  }
 
   return settings;
 }

--- a/common.js
+++ b/common.js
@@ -10,15 +10,9 @@ function getDisplaySettingsFileName() {
 }
 
 function getDisplaySettings() {
-  return new Promise((resolve)=>{
-    platform.readTextFile(getDisplaySettingsFileName())
-      .then((contents)=>{
-        resolve(parsePropertyList(contents));
-      })
-      .catch(()=>{
-        resolve({});
-      });
-  });
+  return platform.readTextFile(getDisplaySettingsFileName())
+  .then((contents) => parsePropertyList(contents))
+  .catch(() => {});
 }
 
 function getTempDisplayId() {

--- a/common.js
+++ b/common.js
@@ -11,6 +11,10 @@ function getDisplaySettingsFileName() {
   return path.join(module.exports.getInstallDir(), "RiseDisplayNetworkII.ini");
 }
 
+function displaySettingsCopy() {
+  return {...displaySettings};
+}
+
 function initDisplaySettings(settings) {
   if (!settings.displayid) {
     const tempDisplayId = "0." + module.exports.getMachineId();
@@ -20,12 +24,12 @@ function initDisplaySettings(settings) {
 
   displaySettings = settings;
 
-  return displaySettings;
+  return displaySettingsCopy();
 }
 
 function getDisplaySettings() {
   if (displaySettings) {
-    return Promise.resolve(displaySettings);
+    return Promise.resolve(displaySettingsCopy());
   }
 
   return platform.readTextFile(getDisplaySettingsFileName())
@@ -53,7 +57,7 @@ function readDisplaySettingsSync() {
 
 function getDisplaySettingsSync() {
   if (displaySettings) {
-    return displaySettings;
+    return displaySettingsCopy();
   }
 
   const settings = readDisplaySettingsSync();
@@ -88,7 +92,7 @@ function updateDisplaySettings(newSettings){
   return getDisplaySettings()
   .then(currentSettings => {
     const displaySettingsFileName = getDisplaySettingsFileName();
-    const updatedSettings = Object.assign({}, currentSettings, newSettings);
+    const updatedSettings = {...currentSettings, ...newSettings};
 
     const updatedSettingsText = Object.keys(updatedSettings)
     .reduce((text, key) => text + (

--- a/common.js
+++ b/common.js
@@ -16,13 +16,10 @@ function displaySettingsCopy() {
 }
 
 function initDisplaySettings(settings) {
-  if (!settings.displayid) {
-    const tempDisplayId = "0." + module.exports.getMachineId();
-
-    settings.tempdisplayid = tempDisplayId;
-  }
-
-  displaySettings = settings;
+  displaySettings = settings.displayid ? settings :
+    Object.assign({}, settings, {
+      tempdisplayid: `0.${module.exports.getMachineId()}`
+    });
 
   return displaySettingsCopy();
 }

--- a/common.js
+++ b/common.js
@@ -21,17 +21,20 @@ function getDisplaySettings() {
   });
 }
 
+function getTempDisplayId() {
+  return "0." + module.exports.getMachineId();
+}
+
 function getDisplaySettingsSync() {
   var settings,
-    tempDisplayId = "0." + module.exports.getMachineId(),
     configExists = platform.fileExists(getDisplaySettingsFileName()),
     textFileString = configExists ? platform.readTextFileSync(getDisplaySettingsFileName()) : "";
 
-  if (!textFileString) {return {tempdisplayid: tempDisplayId};}
+  if (!textFileString) {return {tempdisplayid: getTempDisplayId()};}
 
   settings = parsePropertyList(textFileString);
 
-  if (!settings.displayid) {settings.tempdisplayid = tempDisplayId;}
+  if (!settings.displayid) {settings.tempdisplayid = getTempDisplayId();}
 
   return settings;
 }

--- a/common.js
+++ b/common.js
@@ -24,6 +24,10 @@ function initDisplaySettings(settings) {
 }
 
 function getDisplaySettings() {
+  if (displaySettings) {
+    return Promise.resolve(displaySettings);
+  }
+
   return platform.readTextFile(getDisplaySettingsFileName())
   .then(parsePropertyList)
   .catch(() => {})
@@ -47,6 +51,10 @@ function readDisplaySettings() {
 }
 
 function getDisplaySettingsSync() {
+  if (displaySettings) {
+    return displaySettings;
+  }
+
   const settings = readDisplaySettings();
 
   return initDisplaySettings(settings);
@@ -212,5 +220,8 @@ module.exports = {
   isBetaLauncher() {
     const betaPath = path.join(module.exports.getModulePath("launcher"), "Installer", "BETA");
     return platform.fileExists(betaPath);
+  },
+  clear() {
+    displaySettings = null;
   }
 };

--- a/common.js
+++ b/common.js
@@ -5,14 +5,29 @@ const HttpProxyAgent = require("proxy-agent");
 const HttpsProxyAgent = require("https-proxy-agent");
 global.log = global.log || {error:console.log,debug:console.log};
 
+var displaySettings = null;
+
 function getDisplaySettingsFileName() {
   return path.join(getInstallDir(), "RiseDisplayNetworkII.ini");
+}
+
+function initDisplaySettings(settings) {
+  if (!settings.displayid) {
+    const tempDisplayId = "0." + module.exports.getMachineId();
+
+    settings.tempdisplayid = tempDisplayId;
+  }
+
+  displaySettings = settings;
+
+  return displaySettings;
 }
 
 function getDisplaySettings() {
   return platform.readTextFile(getDisplaySettingsFileName())
   .then(parsePropertyList)
-  .catch(() => {});
+  .catch(() => {})
+  .then(initDisplaySettings);
 }
 
 function readDisplaySettings() {
@@ -34,13 +49,7 @@ function readDisplaySettings() {
 function getDisplaySettingsSync() {
   const settings = readDisplaySettings();
 
-  if (!settings.displayid) {
-    const tempDisplayId = "0." + module.exports.getMachineId();
-
-    settings.tempdisplayid = tempDisplayId;
-  }
-
-  return settings;
+  return initDisplaySettings(settings);
 }
 
 function getDisplayProperty(key) {

--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const {platform} = require("rise-common-electron");
+const platform = require("rise-common-electron").platform;
 const portedPlatform = require("./platform");
 const HttpProxyAgent = require("proxy-agent");
 const HttpsProxyAgent = require("https-proxy-agent");

--- a/common.js
+++ b/common.js
@@ -5,7 +5,7 @@ const HttpProxyAgent = require("proxy-agent");
 const HttpsProxyAgent = require("https-proxy-agent");
 global.log = global.log || {error:console.log,debug:console.log};
 
-var displaySettings = null;
+let displaySettings = null;
 
 function getDisplaySettingsFileName() {
   return path.join(module.exports.getInstallDir(), "RiseDisplayNetworkII.ini");

--- a/common.js
+++ b/common.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const platform = require("rise-common-electron").platform;
+const {platform} = require("rise-common-electron");
 const portedPlatform = require("./platform");
 const HttpProxyAgent = require("proxy-agent");
 const HttpsProxyAgent = require("https-proxy-agent");

--- a/common.js
+++ b/common.js
@@ -96,7 +96,7 @@ function updateDisplaySettings(newSettings){
     ), "");
 
     return platform.writeTextFile(displaySettingsFileName, updatedSettingsText)
-    .then(() => {displaySettings = updatedSettings;});
+    .then(() => (displaySettings = updatedSettings));
   });
 }
 

--- a/common.js
+++ b/common.js
@@ -12,7 +12,7 @@ function getDisplaySettingsFileName() {
 }
 
 function displaySettingsCopy() {
-  return {...displaySettings};
+  return Object.assign({}, displaySettings);
 }
 
 function initDisplaySettings(settings) {
@@ -92,7 +92,7 @@ function updateDisplaySettings(newSettings){
   return getDisplaySettings()
   .then(currentSettings => {
     const displaySettingsFileName = getDisplaySettingsFileName();
-    const updatedSettings = {...currentSettings, ...newSettings};
+    const updatedSettings = Object.assign({}, currentSettings, newSettings);
 
     const updatedSettingsText = Object.keys(updatedSettings)
     .reduce((text, key) => text + (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.0.7",
+  "version": "3.1.0",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -9,7 +9,11 @@ const platform = require("rise-common-electron").platform;
 const common = require("../../common.js");
 
 describe("Config", ()=>{
-  afterEach(()=>{
+  beforeEach(() => {
+    mock(platform, "fileExists").returnWith(true);
+  });
+
+  afterEach(() => {
     simpleMock.restore();
     mockfs.restore();
 
@@ -178,6 +182,7 @@ describe("Config", ()=>{
 
   it("should return false if BETA file does not exist", ()=>{
     mock(common, "getModuleVersion").returnWith("test");
+    mock(platform, "fileExists").returnWith(false);
 
     mockfs({
       [`${platform.getHomeDir()}rvplayer/modules/launcher/test/Installer/`]: {}});

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -39,8 +39,10 @@ describe("Config", ()=>{
   it("does not generate a tempdisplayid if a display id is already set", ()=>{
     mock(platform, "readTextFileSync").returnWith("displayid=something");
 
-    assert.equal(common.getDisplaySettingsSync().displayid, 'something');
-    assert(!common.getDisplaySettingsSync().tempdisplayid);
+    const settings = common.getDisplaySettingsSync();
+
+    assert.equal(settings.displayid, 'something');
+    assert(!settings.tempdisplayid);
   });
 
   it("reads display settings from cache on second synchronous call", ()=>{

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -183,4 +183,51 @@ describe("Config", ()=>{
       assert(!common.isBetaLauncher());
   });
 
+  describe("updateDisplaySettings", ()=>{
+    beforeEach(()=>{
+      mock(platform, "writeTextFile").resolveWith();
+      mock(platform, "readTextFile").resolveWith("existing=data");
+    });
+
+    it("writes to RiseDisplayNetworkII.ini", ()=>{
+      return common.updateDisplaySettings({})
+      .then(() => {
+        assert(platform.writeTextFile.called);
+
+        const filePath = platform.writeTextFile.lastCall.args[0];
+        assert(/rvplayer\/RiseDisplayNetworkII.ini$/.test(filePath));
+      });
+    });
+
+    it("writes new properties", ()=>{
+      return common.updateDisplaySettings({new: "data"})
+      .then(() => {
+        assert(/new=data/.test(platform.writeTextFile.lastCall.args[1]));
+      });
+    });
+
+    it("preserves existing data", ()=>{
+      return common.updateDisplaySettings({new: "data"})
+      .then (() => {
+        assert(/existing=data/.test(platform.writeTextFile.lastCall.args[1]));
+      });
+    });
+
+    it("saves data after updating", ()=>{
+      return common.updateDisplaySettings({new: "data"})
+      .then (() => {
+        mock(platform, "readTextFile").resolveWith("");
+
+        return common.getDisplaySettings();
+      })
+      .then(settings => {
+        assert(!platform.readTextFile.called);
+
+        assert.equal(settings.existing, 'data');
+        assert.equal(settings.new, 'data');
+        assert(settings.tempdisplayid);
+      });
+    });
+  });
+
 });

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -12,6 +12,8 @@ describe("Config", ()=>{
   afterEach(()=>{
     simpleMock.restore();
     mockfs.restore();
+
+    common.clear();
   });
 
   it("gets display settings synchronously", ()=>{


### PR DESCRIPTION
This concentrates the functionality for both reading and updating display settings, and maintains an in-memory copy of settings so it does not need to be read from file every time.

Functionality and tests for updating display settings were copied from launcher.
