### PR TITLE
add get display id sync

### DIFF
--- a/common.js
+++ b/common.js
@@ -120,17 +120,14 @@ function getProxyAgents() {
 }
 
 function getDisplayId() {
-  return new Promise((res) => {
-    module.exports.getDisplaySettings()
-      .then(settings=>{
-        if (!settings.displayid) {
-          const tempDisplayId = "0." + module.exports.getMachineId();
-          res(tempDisplayId);
-        }
+  return module.exports.getDisplaySettings()
+  .then(settings => settings.displayid || settings.tempdisplayid);
+}
 
-        res(settings.displayid);
-      })
-  });
+function getDisplayIdSync() {
+  const settings = module.exports.getDisplaySettingsSync();
+
+  return settings.displayid || settings.tempdisplayid;
 }
 
 function getLatestVersionInManifest() {
@@ -175,6 +172,7 @@ module.exports = {
   getDisplaySettingsSync,
   updateDisplaySettings,
   getDisplayId,
+  getDisplayIdSync,
   getInstallDir,
   getScriptDir() {
     return path.join(module.exports.getInstallDir(), "scripts");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -138,22 +138,38 @@ describe("Config", ()=>{
     assert(!agents.httpsAgent);
   });
 
-  it("should provide display id when display id is read from file", () => {
+  it("should provide display id async when display id is read from file", () => {
     mock(platform, "readTextFile").resolveWith("displayid=abc123");
     return common.getDisplayId()
-      .then((displayId)=>{
-        assert.equal(displayId, "abc123");
-      })
-      .catch(assert.fail);
+    .then((displayId)=>{
+      assert.equal(displayId, "abc123");
+    });
   });
 
-  it("should provide display id from a temp created one", () => {
+  it("should provide display id async from a temp created one", () => {
     mock(platform, "readTextFile").resolveWith("text=test");
     return common.getDisplayId()
-      .then((displayId)=>{
-        assert(displayId);
-      })
-      .catch(assert.fail);
+    .then((displayId)=>{
+      assert(displayId);
+      assert(displayId.startsWith('0.'));
+    });
+  });
+
+  it("should provide display id sync when display id is read from file", () => {
+    mock(platform, "readTextFileSync").returnWith("displayid=abc123");
+
+    const displayId = common.getDisplayIdSync();
+
+    assert.equal(displayId, "abc123");
+  });
+
+  it("should provide display id sync from a temp created one", () => {
+    mock(platform, "readTextFileSync").returnWith("text=test");
+
+    const displayId = common.getDisplayIdSync();
+
+    assert(displayId);
+    assert(displayId.startsWith('0.'));
   });
 
   it("should provide latest version in manifest", () => {


### PR DESCRIPTION
Getting the displayId or temp display id is all over the place in launcher, so it makes sense to centralize that logic here.