### PR TITLE
Fix/infinite recursion in is beta launcher call

### DIFF
--- a/common.js
+++ b/common.js
@@ -196,10 +196,10 @@ module.exports = {
     const moduleManifestEntry = module.exports.getManifest()[name];
     return moduleManifestEntry && moduleManifestEntry.version;
   },
-  getModulePath(name) {
+  getModulePath(name, logErrors = true) {
     const moduleVersion = module.exports.getModuleVersion(name);
     if (!moduleVersion) {
-      log.error(`No version found for ${name}`);
+      logErrors && log.error(`No version found for ${name}`);
       return false;
     }
 
@@ -239,7 +239,7 @@ module.exports = {
   },
   platform: portedPlatform,
   isBetaLauncher() {
-    const modulePath = module.exports.getModulePath("launcher");
+    const modulePath = module.exports.getModulePath("launcher", false);
 
     if (!modulePath) {
       return false;

--- a/common.js
+++ b/common.js
@@ -239,7 +239,13 @@ module.exports = {
   },
   platform: portedPlatform,
   isBetaLauncher() {
-    const betaPath = path.join(module.exports.getModulePath("launcher"), "Installer", "BETA");
+    const modulePath = module.exports.getModulePath("launcher");
+
+    if (!modulePath) {
+      return false;
+    }
+
+    const betaPath = path.join(modulePath, "Installer", "BETA");
     return platform.fileExists(betaPath);
   },
   clear() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -25,7 +25,7 @@ describe("Config", ()=>{
     assert(common.getDisplaySettingsSync().tempdisplayid);
   });
 
-  it("gets module path", ()=>{
+  it("gets module dir", ()=>{
     mock(common, "getInstallDir").returnWith("rvplayer");
     assert.equal(common.getModuleDir(), pathJoin("rvplayer", "modules"));
   });
@@ -185,25 +185,39 @@ describe("Config", ()=>{
     assert.equal(common.getLatestVersionInManifest(), "2017.11.20.23.14");
   });
 
-  it("should return true if BETA file exists", ()=>{
-    mock(common, "getModuleVersion").returnWith("test");
+  describe("updateDisplaySettings", ()=>{
+    it("should return true if BETA file exists", ()=>{
+      mock(common, "getModuleVersion").returnWith("test");
+      mock(log, "error").returnWith();
 
-    mockfs({
-      [`${platform.getHomeDir()}/rvplayer/modules/launcher/test/Installer/`]: {
-        "BETA": ""
-      }});
+      mockfs({
+        [`${platform.getHomeDir()}/rvplayer/modules/launcher/test/Installer/`]: {
+          "BETA": ""
+        }});
 
-      assert(common.isBetaLauncher());
-  });
+        assert(common.isBetaLauncher());
+        assert(!log.error.called);
+    });
 
-  it("should return false if BETA file does not exist", ()=>{
-    mock(common, "getModuleVersion").returnWith("test");
-    mock(platform, "fileExists").returnWith(false);
+    it("should return false if BETA file does not exist", ()=>{
+      mock(common, "getModuleVersion").returnWith("test");
+      mock(platform, "fileExists").returnWith(false);
+      mock(log, "error").returnWith();
 
-    mockfs({
-      [`${platform.getHomeDir()}rvplayer/modules/launcher/test/Installer/`]: {}});
+      mockfs({
+        [`${platform.getHomeDir()}rvplayer/modules/launcher/test/Installer/`]: {}});
+
+        assert(!common.isBetaLauncher());
+        assert(!log.error.called);
+    });
+
+    it("should return false if the launcher module path cannot be obtained", ()=>{
+      mock(common, "getModulePath").returnWith();
+      mock(log, "error").returnWith();
 
       assert(!common.isBetaLauncher());
+      assert(!log.error.called);
+    });
   });
 
   describe("updateDisplaySettings", ()=>{

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -185,8 +185,37 @@ describe("Config", ()=>{
     assert.equal(common.getLatestVersionInManifest(), "2017.11.20.23.14");
   });
 
-  describe("updateDisplaySettings", ()=>{
-    it("should return true if BETA file exists", ()=>{
+  describe("getModulePath", () => {
+    it("should get the module path", () => {
+      mock(common, "getInstallDir").returnWith("base");
+      mock(common, "getModuleVersion").returnWith("1.1");
+      mock(log, "error").returnWith();
+
+      assert.equal(common.getModulePath('launcher'), 'base/modules/launcher/1.1');
+      assert(!log.error.called);
+    });
+
+    it("should not get the module path if the module version cannot be obtained, and should log error", () => {
+      mock(common, "getInstallDir").returnWith("base");
+      mock(common, "getModuleVersion").returnWith();
+      mock(log, "error").returnWith();
+
+      assert(!common.getModulePath('launcher'));
+      assert(log.error.called);
+    });
+
+    it("should not log error if the module version cannot be obtained and logError flag is set to false", () => {
+      mock(common, "getInstallDir").returnWith("base");
+      mock(common, "getModuleVersion").returnWith();
+      mock(log, "error").returnWith();
+
+      assert(!common.getModulePath('launcher', false));
+      assert(!log.error.called);
+    });
+  });
+
+  describe("updateDisplaySettings", () => {
+    it("should return true if BETA file exists", () => {
       mock(common, "getModuleVersion").returnWith("test");
       mock(log, "error").returnWith();
 
@@ -199,7 +228,7 @@ describe("Config", ()=>{
         assert(!log.error.called);
     });
 
-    it("should return false if BETA file does not exist", ()=>{
+    it("should return false if BETA file does not exist", () => {
       mock(common, "getModuleVersion").returnWith("test");
       mock(platform, "fileExists").returnWith(false);
       mock(log, "error").returnWith();
@@ -211,7 +240,7 @@ describe("Config", ()=>{
         assert(!log.error.called);
     });
 
-    it("should return false if the launcher module path cannot be obtained", ()=>{
+    it("should return false if the launcher module path cannot be obtained", () => {
       mock(common, "getModulePath").returnWith();
       mock(log, "error").returnWith();
 


### PR DESCRIPTION
this avoids logging to external logger from functions invoked by isBetaLauncher()