### PR TITLE
Migrate to CCI 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+
+jobs:
+  "test":
+    docker: &DOCKERIMAGE
+      - image: jenkinsrise/cci-latest-node-with-gcloud:0.0.1
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run test
+
+workflows:
+  version: 2
+  test_and_deploy:
+    jobs:
+      - "test"

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  node:
-    version: 7.10.0
-test:
-  post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/mocha/
-    - cp test/test-results.xml $CIRCLE_TEST_REPORTS/mocha


### PR DESCRIPTION
@andrecardoso please review. I removed the collection of test metadata i.e. `cp test/test-results.xml $CIRCLE_TEST_REPORTS/mocha` for now. I will add it back in the next PR when I replace `istanbul` by `nyc`.