### PR TITLE
Read the stage environment setting

### DIFF
--- a/common.js
+++ b/common.js
@@ -248,6 +248,14 @@ module.exports = {
     const betaPath = path.join(modulePath, "Installer", "BETA");
     return platform.fileExists(betaPath);
   },
+  isStageEnvironment() {
+    const displaySettings = getDisplaySettingsSync();
+    if (!displaySettings.environment) {
+      return false;
+    }
+
+    return displaySettings.environment.toLowerCase() === "stage";
+  },
   clear() {
     displaySettings = null;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-display-module",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "",
   "main": "common.js",
   "author": "Rise Vision",

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -185,6 +185,47 @@ describe("Config", ()=>{
     assert.equal(common.getLatestVersionInManifest(), "2017.11.20.23.14");
   });
 
+  it("should return stage environment flag when stage property exists", () => {
+    mock(platform, "readTextFileSync").returnWith("environment=stage");
+
+    const stage = common.isStageEnvironment();
+
+    assert.equal(stage, true);
+  });
+
+  it("should return stage environment flag when stage property exists in different case", () => {
+    mock(platform, "readTextFileSync").returnWith("environment=StAge");
+
+    const stage = common.isStageEnvironment();
+
+    assert.equal(stage, true);
+  });
+
+
+  it("should return stage environment flag when stage property does not exist", () => {
+    mock(platform, "readTextFileSync").returnWith("");
+
+    const stage = common.isStageEnvironment();
+
+    assert.equal(stage, false);
+  });
+
+  it("should return stage environment flag when stage property is empty", () => {
+    mock(platform, "readTextFileSync").returnWith("environment=");
+
+    const stage = common.isStageEnvironment();
+
+    assert.equal(stage, false);
+  });
+
+  it("should return stage environment flag when stage property is not set to stage", () => {
+    mock(platform, "readTextFileSync").returnWith("environment=production");
+
+    const stage = common.isStageEnvironment();
+
+    assert.equal(stage, false);
+  });
+
   describe("getModulePath", () => {
     it("should get the module path", () => {
       mock(common, "getInstallDir").returnWith("base");


### PR DESCRIPTION
## Description
Add `isStageEnvironment` method to read the environment property from display settings

## Motivation and Context
This method will be used to configure player to stage environment

## How Has This Been Tested?
Unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
